### PR TITLE
Update module installation

### DIFF
--- a/modules-pytorch-1.4.0/pointnet2_utils.py
+++ b/modules-pytorch-1.4.0/pointnet2_utils.py
@@ -22,7 +22,7 @@ except:
     import __builtin__ as builtins
 
 try:
-    import pointnet2._ext as _ext
+    import pointnet2_ops._ext as _ext
 except ImportError:
     if not getattr(builtins, "__POINTNET2_SETUP__", False):
         raise ImportError(

--- a/modules-pytorch-1.8.1/pointnet2_utils.py
+++ b/modules-pytorch-1.8.1/pointnet2_utils.py
@@ -23,7 +23,7 @@ except:
     import __builtin__ as builtins
 
 try:
-    import pointnet2._ext as _ext
+    import pointnet2_ops._ext as _ext
 except ImportError:
     if not getattr(builtins, "__POINTNET2_SETUP__", False):
         raise ImportError(


### PR DESCRIPTION
To address issue #11 where the pointnet2 installation imports error out, we updated the `pointnet2_utils.py` file for both Pytorch 1.4.0 & 1.8.1 modules to import from the correct module.